### PR TITLE
Rename to "vue project template"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vuekiecutter
+# Vue Project Template
 
 This is a project boilerplate template designed for building SPAs that will serve as
 front-ends to Girder 4-based servers. The following features are included:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vuekiecutter",
+  "name": "vue-project-template",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Should have done this when the repo name changed, but I forgot.