### PR TITLE
Add reactivity to oauthClient

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,14 +1,17 @@
 <script lang="ts">
-import { defineComponent, inject, computed } from '@vue/composition-api';
+import {
+  defineComponent, inject, computed, reactive,
+} from '@vue/composition-api';
 import OAuthClient from '@girder/oauth-client';
 
 export default defineComponent({
   setup() {
-    const oauthClient = inject<OAuthClient>('oauthClient');
-    if (oauthClient === undefined) {
+    const injectedClient = inject<OAuthClient>('oauthClient');
+    if (injectedClient === undefined) {
       throw new Error('Must provide "oauthClient" into component.');
     }
 
+    const oauthClient = reactive(injectedClient);
     const loginText = computed(() => (oauthClient.isLoggedIn ? 'Logout' : 'Login'));
     const logInOrOut = () => {
       if (oauthClient.isLoggedIn) {


### PR DESCRIPTION
Previous to this change, the "logout" button would not change to "login" if clicked (it wasn't reactive). Logout would still be performed, but the text wouldn't change, leading to a situation where clicking "logout" actually logs you in. 

It's a small change but IMO the main benefit is in displaying how to correctly use the oauth client. It's also possible this is the wrong approach, in which case I'm open to suggestions.